### PR TITLE
[refactor] 좌석 선택 페이지와 결제 페이지에서 보이는 이벤트 제목 동적으로 적용

### DIFF
--- a/src/pages/QueuePage/components/PaymentStep.tsx
+++ b/src/pages/QueuePage/components/PaymentStep.tsx
@@ -12,6 +12,7 @@ import type { PaymentStepProps } from '../types'
 
 export function PaymentStep({
   eventId,
+  eventTitle,
   selectedSeats,
   orderData,
   paymentMethod,
@@ -62,7 +63,7 @@ export function PaymentStep({
             <div className="space-y-4 mb-6">
               <div>
                 <div className="text-sm text-gray-600 mb-1">이벤트</div>
-                <div className="font-semibold">2025 서울 뮤직 페스티벌</div>
+                <div className="font-semibold">{eventTitle}</div>
               </div>
               <Separator />
 

--- a/src/pages/QueuePage/components/PurchaseStep.tsx
+++ b/src/pages/QueuePage/components/PurchaseStep.tsx
@@ -11,6 +11,7 @@ import type { PurchaseStepProps } from '../types'
 
 export function PurchaseStep({
   eventId,
+  eventTitle,
   selectedSeats,
   setSelectedSeats,
   selectedSection,
@@ -112,7 +113,7 @@ export function PurchaseStep({
     <div className="max-w-6xl mx-auto">
       <div className="mb-6">
         <h1 className="text-3xl font-bold mb-2">좌석 선택</h1>
-        <p className="text-gray-600">2025 서울 뮤직 페스티벌</p>
+        <p className="text-gray-600">{eventTitle}</p>
       </div>
 
       <Card className="p-6 mb-6 bg-red-50 border-red-200">
@@ -164,7 +165,7 @@ export function PurchaseStep({
             <div className="space-y-4 mb-6">
               <div>
                 <div className="text-sm text-gray-600 mb-1">이벤트</div>
-                <div className="font-semibold">2025 서울 뮤직 페스티벌</div>
+                <div className="font-semibold">{eventTitle}</div>
               </div>
               <Separator />
 

--- a/src/pages/QueuePage/components/TossPaymentStep.tsx
+++ b/src/pages/QueuePage/components/TossPaymentStep.tsx
@@ -10,6 +10,7 @@ import type { PrepareOrderResponse } from '@/types/order'
 
 interface TossPaymentStepProps {
   eventId: string
+  eventTitle: string
   selectedSeats: number[]
   orderData: PrepareOrderResponse
   onPaymentStart?: () => void  // 결제 시작 콜백
@@ -17,6 +18,7 @@ interface TossPaymentStepProps {
 
 export function TossPaymentStep({
   eventId,
+  eventTitle,
   selectedSeats,
   orderData,
   onPaymentStart,
@@ -113,7 +115,7 @@ export function TossPaymentStep({
             <div className="space-y-4 mb-6">
               <div>
                 <div className="text-sm text-gray-600 mb-1">이벤트</div>
-                <div className="font-semibold">2025 서울 뮤직 페스티벌</div>
+                <div className="font-semibold">{eventTitle}</div>
               </div>
               <Separator />
 

--- a/src/pages/QueuePage/index.tsx
+++ b/src/pages/QueuePage/index.tsx
@@ -2,6 +2,7 @@ import type { ConfirmPaymentResponse, CreateOrderResponse, PrepareOrderResponse 
 import { orderApi } from '@/api/order'
 import { queueApi } from '@/api/queue'
 import { seatsApi } from '@/api/seats'
+import { eventsApi } from '@/api/events'
 import { PaymentSuccessModal } from '@/components/PaymentSuccessModal'
 import { useQueueWebSocket } from '@/hooks/useQueueWebSocket'
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query'
@@ -27,6 +28,11 @@ export default function QueuePage() {
   const { data: queueData } = useSuspenseQuery({
     queryKey: ['queueStatus', id],
     queryFn: () => queueApi.getQueueStatus(id),
+  })
+
+  const { data: eventData } = useSuspenseQuery({
+    queryKey: ['event', id],
+    queryFn: () => eventsApi.getEventById(id),
   })
 
   const getInitialStep = (): QueueStep => {
@@ -265,6 +271,7 @@ export default function QueuePage() {
   const currentWaitingAhead = waitingAhead ?? queueData.data.waitingAhead ?? 0
   const currentEstimatedTime = estimatedWaitTime ?? queueData.data.estimatedWaitTime ?? 0
   const currentProgress = progress != null ? progress : queueData.data.progress ?? 0
+  const eventTitle = eventData.data.title
 
   return (
     <div className="min-h-screen">
@@ -293,6 +300,7 @@ export default function QueuePage() {
         {step === 'purchase' && (
           <PurchaseStep
             eventId={id}
+            eventTitle={eventTitle}
             selectedSeats={selectedSeats}
             setSelectedSeats={setSelectedSeats}
             selectedSection={selectedSection}
@@ -307,6 +315,7 @@ export default function QueuePage() {
           useTossPayments && tossOrderData ? (
             <TossPaymentStep
               eventId={id}
+              eventTitle={eventTitle}
               selectedSeats={selectedSeats}
               orderData={tossOrderData}
               onPaymentStart={() => {
@@ -318,6 +327,7 @@ export default function QueuePage() {
           ) : orderData ? (
             <PaymentStep
               eventId={id}
+              eventTitle={eventTitle}
               selectedSeats={selectedSeats}
               orderData={orderData}
               paymentMethod={paymentMethod}

--- a/src/pages/QueuePage/types.ts
+++ b/src/pages/QueuePage/types.ts
@@ -27,6 +27,7 @@ export interface ReadyStepProps {
 
 export interface PurchaseStepProps {
   eventId: string
+  eventTitle: string
   selectedSeats: number[]
   setSelectedSeats: Dispatch<SetStateAction<number[]>>
   selectedSection: string
@@ -38,6 +39,7 @@ export interface PurchaseStepProps {
 
 export interface PaymentStepProps {
   eventId: string
+  eventTitle: string
   selectedSeats: number[]
   orderData: CreateOrderResponse
   paymentMethod: string


### PR DESCRIPTION
### 작업 개요
- 기존 : 텍스트 고정
- 좌석 선택 페이지 : 좌측 상단 이벤트 제목 동적으로 적용, 우측 선택 정보창의 이벤트 제목 동적으로 적용
- 결제 페이지 : 우측 결제 정보 창의 이벤트 제목 동적으로 적용
---
### 작업 내용
- QueuePage (index.tsx)
    - eventsApi.getEventById()를 사용해 이벤트 정보를 가져옴
    - 자식 컴포넌트들(PurchaseStep, PaymentStep, TossPaymentStep)에 eventTitle prop 전달

<img width="900" height="307" alt="image" src="https://github.com/user-attachments/assets/a86ef53e-211a-489f-bba2-143e6ea63fac" />
<img width="387" height="209" alt="image" src="https://github.com/user-attachments/assets/ffa70e3b-1f16-48ee-b2bb-7a6aa8031cd2" />

---
이슈번호 #46 