### PR TITLE
[refactor] 결제 v2 :  결제 진행중 flag 이용하여 successUrl로 이동시 alert 비활성화

### DIFF
--- a/src/pages/QueuePage/hooks/useQueueExitGuard.ts
+++ b/src/pages/QueuePage/hooks/useQueueExitGuard.ts
@@ -57,6 +57,13 @@ export function useQueueExitGuard({
 
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {
       if (!handlersRegisteredRef.current) return
+
+      // 결제 진행 중이면 페이지 이탈 방지 안 함
+      if (isPaymentInProgress) {
+        console.log('[QueueExitGuard] 결제 진행 중이므로 beforeunload 스킵')
+        return
+      }
+
       e.preventDefault()
       return ''
     }


### PR DESCRIPTION
- 현재 : 결제 v2에서 결제 프로세스가 끝나면 successUrl로 이동시 "페이지 나감" alert 발생
- 수정 :  isPaymentInProgress 플래그를 이용하여 해당 시점에는 alert 비활성화