### PR TITLE
feat: 좌석조회 grade filter적용, 선택과 선택취소api 정리

### DIFF
--- a/src/api/seats.ts
+++ b/src/api/seats.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '@/lib/axios'
 import type { ApiResponse } from '@/types/api'
+import type { SeatGrade } from '@/types/seat'
 
 export interface Seat {
   id: number
@@ -22,8 +23,11 @@ export interface SeatSelectResponse {
 }
 
 export const seatsApi = {
-  getSeats: async (eventId: string): Promise<ApiResponse<Seat[]>> => {
-    const response = await apiClient.get<ApiResponse<Seat[]>>(`/events/${eventId}/seats`)
+  getSeats: async (eventId: string, grade?: SeatGrade): Promise<ApiResponse<Seat[]>> => {
+    const params = grade ? { grade } : undefined
+    const response = await apiClient.get<ApiResponse<Seat[]>>(`/events/${eventId}/seats`, {
+      params,
+    })
 
     if (response.data.status === '400 BAD_REQUEST') {
       throw Error(response.data.message)

--- a/src/components/SeatMap/index.tsx
+++ b/src/components/SeatMap/index.tsx
@@ -36,8 +36,9 @@ export function SeatMap({
     })
   })
 
-  const handleSeatClick = (seatId: number, seatStatus: string) => {
-    if (seatStatus !== 'AVAILABLE') return
+  const handleSeatClick = (seatId: number, seatStatus: string, isSelected: boolean) => {
+    // 선택된 좌석은 해제 가능, 그 외에는 AVAILABLE만 선택 가능
+    if (!isSelected && seatStatus !== 'AVAILABLE') return
 
     onSeatClick(seatId)
   }
@@ -64,13 +65,13 @@ export function SeatMap({
               <div className="flex-1 flex justify-center gap-2">
                 {seatsByRow[row].map((seat) => {
                   const { number } = parseSeatCode(seat.seatCode)
-                  const isOccupied = seat.seatStatus !== 'AVAILABLE'
                   const isSelected = selectedSeatIds.includes(seat.id)
+                  const isOccupied = seat.seatStatus !== 'AVAILABLE' && !isSelected
 
                   return (
                     <button
                       key={seat.id}
-                      onClick={() => handleSeatClick(seat.id, seat.seatStatus)}
+                      onClick={() => handleSeatClick(seat.id, seat.seatStatus, isSelected)}
                       disabled={isOccupied}
                       className={cn(
                         'w-8 h-8 rounded-t-lg border-2 text-xs font-semibold transition-all',
@@ -79,9 +80,9 @@ export function SeatMap({
                         !isOccupied &&
                           !isSelected &&
                           'bg-white border-gray-300 hover:border-blue-600 hover:bg-blue-50 cursor-pointer',
-                        isSelected && 'bg-blue-600 border-blue-600 text-white scale-110',
+                        isSelected && 'bg-blue-600 border-blue-600 text-white scale-110 cursor-pointer',
                       )}
-                      title={isOccupied ? '선택 불가' : `${number}번`}
+                      title={isSelected ? `${number}번 (클릭하여 해제)` : isOccupied ? '선택 불가' : `${number}번`}
                     >
                       {number}
                     </button>

--- a/src/types/seat.ts
+++ b/src/types/seat.ts
@@ -1,4 +1,5 @@
 export type SeatStatus = 'AVAILABLE' | 'SOLD' | 'RESERVED'
+export type SeatGrade = 'VIP' | 'R' | 'S' | 'A'
 
 export interface Seat {
   id: number


### PR DESCRIPTION
## 변경사항
- 좌석 조회 grade 별로 요청보내도록 수정, 기본 vip grade부터 조회
- 탭으로 다른 grade변경시에 최초 1회만 조회하고 이후에는 좌석맵에 웹소켓변경사항 수신후 반영
- /select api로 바로 다른 좌석으로 변경요청 가능하도록 변경
- /deseletct api로 기존 선택한 좌석 취소 가능하도록 변경